### PR TITLE
記事のタイムスタンプを本文と分離し、YouTube埋め込みに対応したレイアウトを調整

### DIFF
--- a/src/components/ContentDisplay.jsx
+++ b/src/components/ContentDisplay.jsx
@@ -6,12 +6,10 @@ import { style } from '../styles/styles';
 
 const ContentDisplay = ({ page, pageHTML }) => (
   <div style={style.articleCard}>
-    <div style={style.textRight}>
-      <p>
-        作成日時：{formatDate(page.created)}
-        <br />
-        更新日時：{formatDate(page.updated)}
-      </p>
+    {/* 記事のメタ情報 */}
+    <div className="article-meta">
+      <p>作成日時：{formatDate(page.created)}</p>
+      <p>更新日時：{formatDate(page.updated)}</p>
     </div>
     {/* HTML埋め込みをレスポンシブ対応 */}
     <div
@@ -23,6 +21,8 @@ const ContentDisplay = ({ page, pageHTML }) => (
         ),
       }}
     />
+
+    {/* タグ */}
     <div style={style.tags}>
       {page.tags.map((tag) => (
         <Link key={tag} to={`/tag/${tag}`} style={style.tag} className="tag">

--- a/src/components/ContentDisplay.jsx
+++ b/src/components/ContentDisplay.jsx
@@ -13,7 +13,16 @@ const ContentDisplay = ({ page, pageHTML }) => (
         更新日時：{formatDate(page.updated)}
       </p>
     </div>
-    <div dangerouslySetInnerHTML={{ __html: pageHTML }} />
+    {/* HTML埋め込みをレスポンシブ対応 */}
+    <div
+      dangerouslySetInnerHTML={{
+        __html: pageHTML.replace(
+          /<iframe .*?<\/iframe>/g,
+          (iframe) =>
+            `<div class="youtube-wrapper">${iframe}</div>`
+        ),
+      }}
+    />
     <div style={style.tags}>
       {page.tags.map((tag) => (
         <Link key={tag} to={`/tag/${tag}`} style={style.tag} className="tag">

--- a/src/styles/ContentPage.css
+++ b/src/styles/ContentPage.css
@@ -194,3 +194,14 @@ img {
     height: auto;
   }
 }
+
+/* 記事のメタ情報（作成日時・更新日時） */
+.article-meta {
+  position: relative;
+  text-align: right;
+  font-size: 0.9rem;
+}
+
+.article-meta p {
+  margin: 0;
+}

--- a/src/styles/ContentPage.css
+++ b/src/styles/ContentPage.css
@@ -155,3 +155,42 @@ img {
     height: auto;
   }
 }
+
+/* テーブルをラップするコンテナ */
+.table-container {
+  max-width: 100%; /* 親要素に収まるように設定 */
+  overflow-x: auto;
+}
+
+/* 画像のレスポンシブ対応 */
+img {
+  max-width: 100%; /* 親要素の幅に収まる */
+  height: auto;
+  display: block;
+  margin: 0 auto; /* 中央揃え */
+}
+
+/* YouTube埋め込みのレスポンシブ対応 */
+.youtube-wrapper {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 アスペクト比 */
+  margin-bottom: 20px;
+}
+
+.youtube-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+/* スマホ対応 */
+@media only screen and (max-width: 767px) {
+  .article-card img {
+    max-width: 100%;
+    height: auto;
+  }
+}


### PR DESCRIPTION
- 作成日時・更新日時が記事本体と重ならないよう修正しました。  
- YouTube埋め込みがある場合のレイアウトも調整し、視認性を向上させています。